### PR TITLE
feature(IP-1815): 라이브 서비스용 cdk 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ aicd.sh 등의 스크립트를 실행하여 유저 정보를 `~/.aws/config`에 
    --es-host 'vpc-ad-data-es-dev-6roglhwk4hzx2is4lo7zno5wme.ap-northeast-2.es.amazonaws.com' \
    --profile 'deali-sandbox'
    ```   
+   > vpn 연결 필요
+
+   `GET /_cat/indices` 로 인덱스 생성 확인
 
 5. 배포한 애플리케이션을 삭제하려면, `cdk destroy` 명령어를 아래와 같이 실행 합니다.
     ```shell script

--- a/data_analytics_system/data_analytics_system_stack.py
+++ b/data_analytics_system/data_analytics_system_stack.py
@@ -58,6 +58,7 @@ class DataAnalyticsSystemStack(Stack):
     cdk.Tags.of(sg_es).add('Name', 'es-cluster-sg')
 
     sg_es.add_ingress_rule(peer=sg_es, connection=aws_ec2.Port.all_tcp(), description='es-cluster-sg')
+    sg_es.add_ingress_rule(peer=aws_ec2.Peer.ipv4("10.0.0.0/8"), connection=aws_ec2.Port.all_tcp(), description='connect-es-cluster-sg')
     sg_es.add_ingress_rule(peer=sg_use_es, connection=aws_ec2.Port.all_tcp(), description='use-es-cluster-sg')
 
     s3_bucket = s3.Bucket(self, "s3bucketBelugaAdAction",
@@ -189,7 +190,7 @@ class DataAnalyticsSystemStack(Stack):
         "volumeType": "gp2"
       },
       domain_name=es_domain_name,
-      elasticsearch_version="7.8",
+      elasticsearch_version="7.10",
       encryption_at_rest_options={
         "enabled": False
       },

--- a/data_analytics_system/data_analytics_system_stack.py
+++ b/data_analytics_system/data_analytics_system_stack.py
@@ -313,7 +313,8 @@ class DataAnalyticsSystemStack(Stack):
           role_arn=firehose_role.role_arn,
           subnet_ids=es_cfn_domain.vpc_options.subnet_ids,
           security_group_ids=es_cfn_domain.vpc_options.security_group_ids
-        )
+        ),
+        index_rotation_period="NoRotation"
       ),
     )
 

--- a/src/main/python/ETL/etl_beluga_ad_action.py
+++ b/src/main/python/ETL/etl_beluga_ad_action.py
@@ -23,6 +23,7 @@ def lambda_handler(event, context):
   for record in event['records']:
       data = base64.b64decode(record['data']) 
       json_data = json.loads(data)
+      print('json data: {}'.format(json_data))
       json_data['content']['bidPrice'] = decrypt(json_data['content']['bidPrice'], dec_pw, dec_salt)
       new_data = flatten_json(json_data)
   
@@ -61,7 +62,7 @@ def flatten_json(y):
               flatten(a, str(i) + '_') 
               i += 1
       else: 
-          out[name[:-1]] = x 
+          out[name[:-1]] = x if x != '<null>' else None
 
   flatten(y) 
   return out


### PR DESCRIPTION
## 에픽명
- 광고 데이터 파이프라인

## 작업내용
- [fix(IP-1815): es 설정 수정](https://github.com/dealicious-inc/ad-data-pipeline/commit/0258347014f19634da6d0e0abbc3ab8f4fc10ae8)
- [docs(IP-1815): readme에 es관련 설명추가](https://github.com/dealicious-inc/ad-data-pipeline/commit/3cfd0c3f3ca2da96c7acbbc52bbbf1b6d1e73645)
- [fix(IP-1815): flatten 작업 시 ios에서 넘어오는 null 처리](https://github.com/dealicious-inc/ad-data-pipeline/commit/ead63e4590990fb35586cc06bf265eca5875ad43)
- [feat(IP-1815): kinesis -> es로 가는 파이어호스 설정](https://github.com/dealicious-inc/ad-data-pipeline/commit/06d8889ab18caf88b8dd8d7ec616e7e87a592a8a)

## 중요리뷰

키네시스 데이터 스트림 -> 오픈서치(엘라스틱서치)를 연결시켜주는 부분입니다.

관리 용의성을 위해 람다 대신 파이어호스를 사용했고, 해당 부분과 오픈서치와 엘라스틱서치 취사선택은 다음 주 AWS SA와 미팅하며 질의 예정입니다.

![image](https://user-images.githubusercontent.com/24666330/189046185-a758824e-3b96-41fb-90e3-f1e917499944.png)


## 특이사항
- [ ] 타서비스 연동
- [ ] 추가 라이브러리
